### PR TITLE
Update to be compatible with Singletons 2.5.1

### DIFF
--- a/ghc-typelits-presburger.cabal
+++ b/ghc-typelits-presburger.cabal
@@ -30,10 +30,10 @@ library
   other-modules:       GHC.Compat
                        Data.Integer.SAT
   build-depends:       base                 >= 4.7  && < 5
-                     , ghc                  >= 7.10 && < 8.5
+                     , ghc                  >= 7.10 && < 8.7
                      , ghc-tcplugins-extra  >= 0.2  && < 0.4
                      , equational-reasoning >= 0.4.0.0
-                     , singletons
+                     , singletons           < 2.6
                      , transformers
                      , mtl
                      , containers

--- a/stack-806.yaml
+++ b/stack-806.yaml
@@ -1,0 +1,10 @@
+resolver: lts-14.4
+skip-ghc-check: true
+
+flags: {}
+packages:
+- '.'
+
+extra-deps: 
+ - equational-reasoning-0.6.0.0
+

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-stack-804.yaml
+stack-806.yaml


### PR DESCRIPTION
Update presburger version. 
It is necessary for successful compiling type-natural with ghc-8.6.5