### PR TITLE
Started working on GHC 9.2 support

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -19,6 +19,9 @@ jobs:
       matrix:
         ghc: ['8.6.5', '8.8.4', '8.10.7', '9.0.1']
         HEAD: [false]
+        include:
+        - ghc: 9.2.1
+          HEAD: true
 
     runs-on: ubuntu-latest
     name: Haskell GHC ${{ matrix.ghc }} Build
@@ -82,6 +85,9 @@ jobs:
       matrix:
         ghc: ['8.6.5', '8.8.4', '8.10.7', '9.0.1']
         HEAD: [false]
+        include:
+        - ghc: 9.2.1
+          HEAD: true
 
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -17,11 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['8.6.5', '8.8.4', '8.10.7', '9.0.1']
+        ghc: ['8.6.5', '8.8.4', '8.10.7', '9.0.1', '9.2.1']
         HEAD: [false]
-        include:
-        - ghc: 9.2.1
-          HEAD: true
 
     runs-on: ubuntu-latest
     name: Haskell GHC ${{ matrix.ghc }} Build
@@ -83,11 +80,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['8.6.5', '8.8.4', '8.10.7', '9.0.1']
+        ghc: ['8.6.5', '8.8.4', '8.10.7', '9.0.1', '9.2.1']
         HEAD: [false]
-        include:
-        - ghc: 9.2.1
-          HEAD: true
 
     runs-on: ubuntu-latest
     needs:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,8 +5,9 @@ pull_request_rules:
       - "label=merge me"
       - status-success=Haskell GHC 8.6.5 Test
       - status-success=Haskell GHC 8.8.4 Test
-      - status-success=Haskell GHC 8.10.4 Test
+      - status-success=Haskell GHC 8.10.7 Test
       - status-success=Haskell GHC 9.0.1 Test
+      - status-success=Haskell GHC 9.2.1 Test
     actions:
       merge:
         strict: smart+fasttrack

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,13 @@
+
+queue_rules:
+- name: default
+  conditions:
+  - status-success=Haskell GHC 8.6.5 Test
+  - status-success=Haskell GHC 8.8.4 Test
+  - status-success=Haskell GHC 8.10.7 Test
+  - status-success=Haskell GHC 9.0.1 Test
+  - status-success=Haskell GHC 9.2.1 Test
+
 pull_request_rules:
   - name: Automatic merge on approval
     conditions:
@@ -9,6 +19,6 @@ pull_request_rules:
       - status-success=Haskell GHC 9.0.1 Test
       - status-success=Haskell GHC 9.2.1 Test
     actions:
-      merge:
-        strict: smart+fasttrack
+      queue:
         method: squash
+        name: default

--- a/ghc-typelits-presburger/ghc-typelits-presburger.cabal
+++ b/ghc-typelits-presburger/ghc-typelits-presburger.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 38e78a5bab9f9903cdbedcd717417e4b6ce8ec83c9281c2576a213fb2991a7ef
+-- hash: 736029a007677a6ed0ef46f2c516bc8952e3f2c69e4bd56034d20d8b268f36b7
 
 name:           ghc-typelits-presburger
 version:        0.6.0.0
@@ -30,7 +30,7 @@ copyright:      2015 (c) Hiromi ISHII
 license:        BSD3
 license-file:   LICENSE
 tested-with:
-    GHC==8.6.5 GHC==8.8.4 GHC==8.10.7 GHC==9.0.1
+    GHC==8.6.5 GHC==8.8.4 GHC==8.10.7 GHC==9.0.1 GHC==9.2.1
 build-type:     Simple
 
 source-repository head

--- a/ghc-typelits-presburger/ghc-typelits-presburger.cabal
+++ b/ghc-typelits-presburger/ghc-typelits-presburger.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3fe60043238aebd8257e1ef49ad7cc604c5f20f6a8dffa862c4173b83ce5879a
+-- hash: 38e78a5bab9f9903cdbedcd717417e4b6ce8ec83c9281c2576a213fb2991a7ef
 
 name:           ghc-typelits-presburger
 version:        0.6.0.0
@@ -56,7 +56,7 @@ library
   build-depends:
       base >=4.7 && <5
     , containers
-    , ghc <9.1
+    , ghc <9.3
     , ghc-tcplugins-extra >=0.2 && <0.5
     , mtl
     , pretty

--- a/ghc-typelits-presburger/package.yaml
+++ b/ghc-typelits-presburger/package.yaml
@@ -44,7 +44,7 @@ library:
     - reflection
     - syb
     - transformers
-    - ghc < 9.1
+    - ghc < 9.3
 executables:
   simple-arith-core:
     main: simple-arith-core.hs

--- a/ghc-typelits-presburger/package.yaml
+++ b/ghc-typelits-presburger/package.yaml
@@ -20,7 +20,7 @@ maintainer: konn.jinro _at_ gmail.com
 copyright: 2015 (c) Hiromi ISHII
 license: BSD3
 github: konn/ghc-typelits-presburger
-tested-with: GHC==8.6.5 GHC==8.8.4 GHC==8.10.7 GHC==9.0.1
+tested-with: GHC==8.6.5 GHC==8.8.4 GHC==8.10.7 GHC==9.0.1 GHC==9.2.1
 ghc-options:
   - -Wall
   - -Wno-dodgy-imports

--- a/ghc-typelits-presburger/src/GHC/TypeLits/Presburger/Compat.hs
+++ b/ghc-typelits-presburger/src/GHC/TypeLits/Presburger/Compat.hs
@@ -127,7 +127,7 @@ import GHC.Utils.Outputable as GHC.TypeLits.Presburger.Compat (showSDocUnsafe)
 #else
 import Class as GHC.TypeLits.Presburger.Compat (classTyCon, className)
 import FastString as GHC.TypeLits.Presburger.Compat (FastString, fsLit, unpackFS)
-import GhcPlugins (InScopeSet, Outputable, emptyUFM, InstalledUnitId(..), initPackages)
+import GhcPlugins (InScopeSet, Outputable, emptyUFM, InstalledUnitId(..), initPackages, Name)
 import GhcPlugins as GHC.TypeLits.Presburger.Compat (PackageName (..), fsToUnitId, lookupPackageName, lookupTyCon, mkTcOcc, mkTyConTy, ppr, promotedFalseDataCon, promotedTrueDataCon, text, tyConAppTyCon_maybe, typeKind, typeNatKind)
 import HscTypes as GHC.TypeLits.Presburger.Compat (HscEnv (hsc_dflags))
 import Module as GHC.TypeLits.Presburger.Compat (ModuleName, mkModuleName, mkModule)
@@ -464,6 +464,59 @@ lookupTyNatBoolLeq =
   pure typeNatLeqTyCon
 #endif
 
+lookupTyNatPredLt :: TcPluginM (Maybe TyCon)
+#if MIN_VERSION_ghc(9,2,0)
+lookupTyNatPredLt = Just <$> do
+  tyOrd <- lookupModule (mkModuleName "Data.Type.Ord") "base"
+  tcLookupTyCon =<< lookupOrig tyOrd (mkTcOcc "<")
+#else
+lookupTyNatPredLt = pure Nothing
+#endif
+
+lookupTyNatBoolLt :: TcPluginM (Maybe TyCon)
+#if MIN_VERSION_ghc(9,2,0)
+lookupTyNatBoolLt = do
+  tyOrd <- lookupModule (mkModuleName "Data.Type.Ord") "base"
+  tcLookupTyCon =<< lookupOrig tyOrd (mkTcOcc "<?")
+#else
+lookupTyNatBoolLt = pure Nothing
+#endif
+
+lookupTyNatPredGt :: TcPluginM (Maybe TyCon)
+#if MIN_VERSION_ghc(9,2,0)
+lookupTyNatPredGt = Just <$> do
+  tyOrd <- lookupModule (mkModuleName "Data.Type.Ord") "base"
+  tcLookupTyCon =<< lookupOrig tyOrd (mkTcOcc ">")
+#else
+lookupTyNatPredGt = pure Nothing
+#endif
+
+lookupTyNatBoolGt :: TcPluginM (Maybe TyCon)
+#if MIN_VERSION_ghc(9,2,0)
+lookupTyNatBoolGt = do
+  tyOrd <- lookupModule (mkModuleName "Data.Type.Ord") "base"
+  tcLookupTyCon =<< lookupOrig tyOrd (mkTcOcc ">?")
+#else
+lookupTyNatBoolGt = pure Nothing
+#endif
+
+lookupTyNatPredGeq :: TcPluginM (Maybe TyCon)
+#if MIN_VERSION_ghc(9,2,0)
+lookupTyNatPredGeq = Just <$> do
+  tyOrd <- lookupModule (mkModuleName "Data.Type.Ord") "base"
+  tcLookupTyCon =<< lookupOrig tyOrd (mkTcOcc ">=")
+#else
+lookupTyNatPredGeq = pure Nothing
+#endif
+
+lookupTyNatBoolGeq :: TcPluginM (Maybe TyCon)
+#if MIN_VERSION_ghc(9,2,0)
+lookupTyNatBoolGeq = Just <$> do
+  tyOrd <- lookupModule (mkModuleName "Data.Type.Ord") "base"
+  tcLookupTyCon =<< lookupOrig tyOrd (mkTcOcc ">=?")
+#else
+lookupTyNatBoolGeq = pure Nothing
+#endif
 
 mOrdCondTyCon :: TcPluginM (Maybe TyCon)
 #if MIN_VERSION_ghc(9,2,0)
@@ -473,4 +526,3 @@ mOrdCondTyCon = Just <$> do
 #else
 mOrdCondTyCon = pure Nothing
 #endif
-

--- a/ghc-typelits-presburger/src/GHC/TypeLits/Presburger/Compat.hs
+++ b/ghc-typelits-presburger/src/GHC/TypeLits/Presburger/Compat.hs
@@ -436,3 +436,10 @@ typeNatKind :: TcType
 typeNatKind = naturalTy
 #endif
 
+mtypeNatLeqTyCon :: Maybe TyCon
+#if MIN_VERSION_ghc(9,2,0)
+mtypeNatLeqTyCon = Nothing
+#else
+mtypeNatLeqTyCon = Just typeNatLeqTyCon
+#endif
+

--- a/ghc-typelits-presburger/src/GHC/TypeLits/Presburger/Compat.hs
+++ b/ghc-typelits-presburger/src/GHC/TypeLits/Presburger/Compat.hs
@@ -475,7 +475,7 @@ lookupTyNatPredLt = pure Nothing
 
 lookupTyNatBoolLt :: TcPluginM (Maybe TyCon)
 #if MIN_VERSION_ghc(9,2,0)
-lookupTyNatBoolLt = do
+lookupTyNatBoolLt = Just <$> do
   tyOrd <- lookupModule (mkModuleName "Data.Type.Ord") "base"
   tcLookupTyCon =<< lookupOrig tyOrd (mkTcOcc "<?")
 #else
@@ -493,7 +493,7 @@ lookupTyNatPredGt = pure Nothing
 
 lookupTyNatBoolGt :: TcPluginM (Maybe TyCon)
 #if MIN_VERSION_ghc(9,2,0)
-lookupTyNatBoolGt = do
+lookupTyNatBoolGt = Just <$> do
   tyOrd <- lookupModule (mkModuleName "Data.Type.Ord") "base"
   tcLookupTyCon =<< lookupOrig tyOrd (mkTcOcc ">?")
 #else

--- a/ghc-typelits-presburger/src/GHC/TypeLits/Presburger/Compat.hs
+++ b/ghc-typelits-presburger/src/GHC/TypeLits/Presburger/Compat.hs
@@ -106,6 +106,7 @@ import GHC.Tc.Plugin as GHC.TypeLits.Presburger.Compat
 import GHC.Tc.Types as GHC.TypeLits.Presburger.Compat (TcPlugin (..), TcPluginResult (..))
 import GHC.Tc.Types.Constraint as GHC.TypeLits.Presburger.Compat
   ( Ct,
+    CtEvidence,
     ctEvPred,
     ctEvidence,
     isWanted,
@@ -195,7 +196,7 @@ import GHC (NoExtField(..))
 import qualified Predicate as Old (classifyPredType)
 import Predicate as GHC.TypeLits.Presburger.Compat  (mkPrimEqPredRole)
 import Constraint as GHC.TypeLits.Presburger.Compat 
-    (Ct, ctEvidence, ctEvPred, isWanted)
+    (Ct, ctEvidence, CtEvidence, ctEvPred, isWanted)
 #else
 import GHC (NoExt(..))
 import GhcPlugins as GHC.TypeLits.Presburger.Compat (EqRel (..), PredTree (..))

--- a/ghc-typelits-presburger/src/GHC/TypeLits/Presburger/Compat.hs
+++ b/ghc-typelits-presburger/src/GHC/TypeLits/Presburger/Compat.hs
@@ -465,7 +465,9 @@ lookupTyNatBoolLeq =
 #endif
 
 lookupTyNatPredLt :: TcPluginM (Maybe TyCon)
-#if MIN_VERSION_ghc(9,2,0)
+-- Note:  base library shipepd with 9.2.1 has a wrong implementation;
+-- hence we MUST NOT desugar it with <= 9.2.1
+#if MIN_VERSION_ghc(9,2,2)
 lookupTyNatPredLt = Just <$> do
   tyOrd <- lookupModule (mkModuleName "Data.Type.Ord") "base"
   tcLookupTyCon =<< lookupOrig tyOrd (mkTcOcc "<")
@@ -525,4 +527,13 @@ mOrdCondTyCon = Just <$> do
   tcLookupTyCon =<< lookupOrig tyOrd (mkTcOcc "OrdCond")
 #else
 mOrdCondTyCon = pure Nothing
+#endif
+
+lookupTyGenericCompare :: TcPluginM (Maybe TyCon)
+#if MIN_VERSION_ghc(9,2,0)
+lookupTyGenericCompare = Just <$> do
+  tyOrd <- lookupModule (mkModuleName "Data.Type.Ord") "base"
+  tcLookupTyCon =<< lookupOrig tyOrd (mkTcOcc "Compare")
+#else
+lookupTyGenericCompare = pure Nothing
 #endif

--- a/ghc-typelits-presburger/src/GHC/TypeLits/Presburger/Types.hs
+++ b/ghc-typelits-presburger/src/GHC/TypeLits/Presburger/Types.hs
@@ -12,7 +12,6 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# OPTIONS_GHC -fmax-pmcheck-models=100 #-}
 -- | Since 0.3.0.0
 module GHC.TypeLits.Presburger.Types
   ( pluginWith,

--- a/ghc-typelits-presburger/src/GHC/TypeLits/Presburger/Types.hs
+++ b/ghc-typelits-presburger/src/GHC/TypeLits/Presburger/Types.hs
@@ -27,7 +27,7 @@ module GHC.TypeLits.Presburger.Types
 where
 
 import Control.Applicative ((<|>))
-import Control.Arrow (second, (***))
+import Control.Arrow (second)
 import Control.Monad (forM_, guard, mzero, unless)
 import Control.Monad.State.Class
 import Control.Monad.Trans.Class
@@ -314,7 +314,6 @@ decidePresburger mode genTrans _ gs _ds ws = do
           | ct <- solved
           , EqPred NomEq t1 t2 <- return (classifyPredType $ deconsPred ct)
           ]
-    tcPluginTrace "binPropDic keys: " (ppr $ map (ppr *** text . show . (\f -> f (K 0) (K 1))) binPropDic)
     tcPluginTrace "pres: final premises" (text $ show prems0)
     tcPluginTrace "pres: final goals" (text $ show $ map snd wants)
     case testIf prems (foldr ((:&&) . snd) PTrue wants) of

--- a/ghc-typelits-presburger/src/GHC/TypeLits/Presburger/Types.hs
+++ b/ghc-typelits-presburger/src/GHC/TypeLits/Presburger/Types.hs
@@ -133,7 +133,7 @@ handleSubtraction DisallowNegatives p0 =
     loop (Not q) = Not <$> loop q
     loop (l :<= r) = (:<=) <$> loopExp l <*> loopExp r
     loop (l :< r) = (:<) <$> loopExp l <*> loopExp r
-    loop (l :>= r) = (:<=) <$> loopExp l <*> loopExp r
+    loop (l :>= r) = (:>=) <$> loopExp l <*> loopExp r
     loop (l :> r) = (:>) <$> loopExp l <*> loopExp r
     loop (l :== r) = (:==) <$> loopExp l <*> loopExp r
     loop (l :/= r) = (:/=) <$> loopExp l <*> loopExp r

--- a/ghc-typelits-presburger/src/GHC/TypeLits/Presburger/Types.hs
+++ b/ghc-typelits-presburger/src/GHC/TypeLits/Presburger/Types.hs
@@ -48,6 +48,7 @@ import Data.Maybe
 import Data.Reflection (Given, give, given)
 import qualified Data.Set as Set
 import GHC.TypeLits.Presburger.Compat
+import qualified Data.Foldable as F
 
 assert' :: Prop -> PropSet -> PropSet
 assert' p ps = foldr assert ps (p : varPos)
@@ -363,7 +364,7 @@ defaultTranslation = do
       , natExp = [typeNatExpTyCon]
       , falseData = [promotedFalseDataCon]
       , trueData = [promotedTrueDataCon]
-      , natLeqBool = [typeNatLeqTyCon]
+      , natLeqBool = F.toList mtypeNatLeqTyCon
       , natLeq = [nLeq]
       , natCompare = [typeNatCmpTyCon]
       , orderingEQ = [promotedEQDataCon]

--- a/ghc-typelits-presburger/src/GHC/TypeLits/Presburger/Types.hs
+++ b/ghc-typelits-presburger/src/GHC/TypeLits/Presburger/Types.hs
@@ -157,6 +157,8 @@ handleSubtraction DisallowNegatives p0 =
     loopExp (Min l r) = Min <$> loopExp l <*> loopExp r
     loopExp (Max l r) = Max <$> loopExp l <*> loopExp r
     loopExp (If p l r) = If <$> loop p <*> loopExp l <*> loopExp r
+    loopExp (Mod l n) = Mod <$> loopExp l <*> pure n
+    loopExp (Div l n) = Div <$> loopExp l <*> pure n
     loopExp e@(K _) = return e
 
 data Translation = Translation

--- a/ghc-typelits-presburger/src/GHC/TypeLits/Presburger/Types.hs
+++ b/ghc-typelits-presburger/src/GHC/TypeLits/Presburger/Types.hs
@@ -356,6 +356,12 @@ defaultTranslation = do
   voidTyCon <- tcLookupTyCon =<< lookupOrig vmd (mkTcOcc "Void")
   nLeq <- tcLookupTyCon =<< lookupTyNatPredLeq
   tyLeqB <- lookupTyNatBoolLeq
+  mTyLtP <- lookupTyNatPredLt
+  mTyLtB <- lookupTyNatBoolLt
+  mTyGeqP <- lookupTyNatPredGeq
+  mTyGeqB <- lookupTyNatBoolGeq
+  mTyGtP <- lookupTyNatPredGt
+  mTyGtB <- lookupTyNatBoolGt
   mOrdCond <- mOrdCondTyCon
   return
     mempty
@@ -374,6 +380,12 @@ defaultTranslation = do
       , trueData = [promotedTrueDataCon]
       , natLeqBool = [tyLeqB]
       , natLeq = [nLeq]
+      , natGeqBool = F.toList mTyGeqB
+      , natGeq = F.toList mTyGeqP
+      , natGtBool = F.toList mTyGtB
+      , natGt = F.toList mTyGtP
+      , natLtBool = F.toList mTyLtB
+      , natLt = F.toList mTyLtP
       , natCompare = [typeNatCmpTyCon]
       , orderingEQ = [promotedEQDataCon]
       , orderingLT = [promotedLTDataCon]

--- a/ghc-typelits-presburger/src/GHC/TypeLits/Presburger/Types.hs
+++ b/ghc-typelits-presburger/src/GHC/TypeLits/Presburger/Types.hs
@@ -25,7 +25,7 @@ where
 
 import Control.Applicative ((<|>))
 import Control.Arrow (second)
-import Control.Monad (forM, forM_, guard, mzero, unless)
+import Control.Monad (forM_, guard, mzero, unless)
 import Control.Monad.State.Class
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Maybe (MaybeT (..))

--- a/singletons-presburger/examples/simple-arith.hs
+++ b/singletons-presburger/examples/simple-arith.hs
@@ -68,7 +68,7 @@ natLeqZero' _ = Refl
 leqSucc :: proxy n -> proxy m -> IsTrue ((n + 1) <= m) -> CmpNat n m :~: 'LT
 leqSucc _ _ Witness = Refl
 
-leqEquiv :: (n <= m) ~ 'True => Sing n -> Sing m -> IsTrue (n <=? m)
+leqEquiv :: (n <= m) ~ 'True => Sing (n :: Nat) -> Sing m -> IsTrue (n <=? m)
 leqEquiv _ _ = Witness
 
 data NatView (n :: Nat) where
@@ -87,7 +87,7 @@ plusLeq _ _ = Refl
 minusLeq :: (n <= m) ~ 'True => proxy (n :: Nat) -> proxy m -> IsTrue ((m - n) + n <= m)
 minusLeq _ _ = Witness
 
-(%:<=?) :: Sing n -> Sing m -> Sing (n <=? m)
+(%:<=?) :: Sing (n :: Nat) -> Sing m -> Sing (n <=? m)
 n %:<=? m = case sCompare n m of
   SLT -> STrue
   SEQ -> STrue

--- a/singletons-presburger/package.yaml
+++ b/singletons-presburger/package.yaml
@@ -15,7 +15,7 @@ maintainer: konn.jinro _at_ gmail.com
 copyright: 2015 (c) Hiromi ISHII
 license: BSD3
 github: konn/ghc-typelits-presburger
-tested-with: GHC==8.6.5 GHC==8.8.4 GHC==8.10.7 GHC==9.0.1
+tested-with: GHC==8.6.5 GHC==8.8.4 GHC==8.10.7 GHC==9.0.1 GHC==9.2.1
 ghc-options:
   - -Wall
   - -Wno-dodgy-imports

--- a/singletons-presburger/singletons-presburger.cabal
+++ b/singletons-presburger/singletons-presburger.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: bb439928e71456fa954e07e40d7b62c2ef5b5349f76cc41075b3b4b1a7b01aa4
+-- hash: 7c819c65945b20693fd8ec236686efb63525a531888046776d078d702094cd2b
 
 name:           singletons-presburger
 version:        0.6.0.0
@@ -25,7 +25,7 @@ copyright:      2015 (c) Hiromi ISHII
 license:        BSD3
 license-file:   LICENSE
 tested-with:
-    GHC==8.6.5 GHC==8.8.4 GHC==8.10.7 GHC==9.0.1
+    GHC==8.6.5 GHC==8.8.4 GHC==8.10.7 GHC==9.0.1 GHC==9.2.1
 build-type:     Simple
 
 source-repository head

--- a/stack-9.2.1.yaml
+++ b/stack-9.2.1.yaml
@@ -1,0 +1,8 @@
+resolver: nightly-2021-11-06
+compiler: ghc-9.2.1
+system-ghc: true
+
+flags: {}
+packages:
+- "ghc-typelits-presburger"
+- "singletons-presburger"

--- a/stack-9.2.1.yaml
+++ b/stack-9.2.1.yaml
@@ -6,3 +6,9 @@ flags: {}
 packages:
 - "ghc-typelits-presburger"
 - "singletons-presburger"
+
+extra-deps:
+- th-desugar-1.13
+- singletons-th-3.1
+- singletons-3.0.1
+- singletons-base-3.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-./stack-8.10.4.yaml
+./stack-9.0.1.yaml


### PR DESCRIPTION
GHC 9.2 includes substantial changes in type-level orderings; we must add non-trivial amount of workaround for that. 
Perhaps, adding extra `parsePred` to ghc-typelits-presburger would be easiest.